### PR TITLE
Migrate to .NET 8.0

### DIFF
--- a/BmsToOsu/BmsToOsu.csproj
+++ b/BmsToOsu/BmsToOsu.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
This is an attempt to migrate to .NET 8.0 as .NET 6.0 has stopped being supported and is considered insecure.

I did a basic test of converting a BMS. It seems to work. Please see if there is any issues with this migration.